### PR TITLE
Add crc32c to pixi via PyPI for osx-arm64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ hs_err_pid*
 .settings
 
 poetry.lock
+# pixi environments
+.pixi
+*.egg-info

--- a/pixi.lock
+++ b/pixi.lock
@@ -478,6 +478,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py310h2665a74_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
+      - pypi: https://files.pythonhosted.org/packages/1e/33/6476918b4cac85a18e32dc754e9d653b0dcd96518d661cbbf91bf8aec8cc/crc32c-2.7.1-cp310-cp310-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/83/50/0a2048895a764b138638b5e7a62436545eb206948a5e6f77d9d5a4b02479/ml_dtypes-0.5.0-cp310-cp310-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/54/18/0fda1812cdba8b52aba354240433b5b7aa46d5a205a25bc0e938c41a06ba/tensorstore-0.1.67-cp310-cp310-macosx_11_0_arm64.whl
       win-64:
@@ -1468,6 +1469,12 @@ packages:
   - pkg:pypi/comm?source=hash-mapping
   size: 12134
   timestamp: 1710320435158
+- kind: pypi
+  name: crc32c
+  version: 2.7.1
+  url: https://files.pythonhosted.org/packages/1e/33/6476918b4cac85a18e32dc754e9d653b0dcd96518d661cbbf91bf8aec8cc/crc32c-2.7.1-cp310-cp310-macosx_11_0_arm64.whl
+  sha256: f4333e62b7844dfde112dbb8489fd2970358eddc3310db21e943a9f6994df749
+  requires_python: '>=3.7'
 - kind: conda
   name: crc32c
   version: 2.7.1

--- a/pixi.toml
+++ b/pixi.toml
@@ -30,3 +30,6 @@ crc32c = ">=2.7.1,<3"
 
 [target.linux-64.dependencies]
 crc32c = ">=2.7.1,<3"
+
+[target.osx-arm64.pypi-dependencies]
+crc32c = ">=2.7.1, <3"


### PR DESCRIPTION
Currently conda-forge does not have an osx-arm64 build of crc32c. However, PyPI does.

For the pixi branch, this pull requests adds crc32c via PyPI for osx-arm64 (new M1, M2, or M3 Macs).